### PR TITLE
Add eslint jsx support; add entry component; use spaces in package.json

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,5 +1,18 @@
 module.exports = {
-	"extends": "standard",
+	"extends": [
+		"standard",
+		"plugin:react/recommended"
+	],
+
+	"parserOptions": {
+		"ecmaFeatures": {
+			"jsx": true
+		}
+	},
+
+	"plugins": [
+		"react"
+	],
 
 	"rules": {
 		"indent": ["error", "tab"]

--- a/package.json
+++ b/package.json
@@ -1,39 +1,40 @@
 {
-	"name": "code-cafe",
-	"version": "0.0.1",
-	"description": "Ad-hoc meetups for social programming",
-	"main": "src/Server/index.js",
-	"scripts": {
-		"unit-tests": "mocha src/**/*spec.js",
-		"lint": "eslint ./**/*.{js,jsx}",
-		"test": "npm run unit-tests && npm run lint",
-		"build": "webpack --watch"
-	},
-	"keywords": [],
-	"author": "Jesse Gibson <jesse@gundb.io> (http://techllama.com)",
-	"license": "UNLICENSED",
-	"repository": {
-		"type": "git",
-		"url": "git+https://github.com/LunaMinds/code-cafe.git"
-	},
-	"bugs": {
-		"url": "https://github.com/LunaMinds/code-cafe/issues"
-	},
-	"homepage": "https://github.com/LunaMinds/code-cafe#readme",
-	"devDependencies": {
-		"babel-core": "^6.10.4",
-		"babel-loader": "^6.2.4",
-		"babel-preset-es2015": "^6.9.0",
-		"babel-preset-react": "^6.5.0",
-		"eslint": "^2.13.1",
-		"eslint-config-standard": "^5.3.1",
-		"eslint-plugin-promise": "^1.3.2",
-		"eslint-plugin-standard": "^1.3.2",
-		"mocha": "^2.5.3",
-		"webpack": "^1.13.1"
-	},
-	"dependencies": {
-		"react": "^15.1.0",
-		"react-dom": "^15.1.0"
-	}
+  "name": "code-cafe",
+  "version": "0.0.1",
+  "description": "Ad-hoc meetups for social programming",
+  "main": "src/Server/index.js",
+  "scripts": {
+    "unit-tests": "mocha src/**/*spec.js",
+    "lint": "eslint src/**/*.{js,jsx}",
+    "test": "npm run unit-tests && npm run lint",
+    "build": "webpack --watch"
+  },
+  "keywords": [],
+  "author": "Jesse Gibson <jesse@gundb.io> (http://techllama.com)",
+  "license": "UNLICENSED",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/LunaMinds/code-cafe.git"
+  },
+  "bugs": {
+    "url": "https://github.com/LunaMinds/code-cafe/issues"
+  },
+  "homepage": "https://github.com/LunaMinds/code-cafe#readme",
+  "devDependencies": {
+    "babel-core": "^6.10.4",
+    "babel-loader": "^6.2.4",
+    "babel-preset-es2015": "^6.9.0",
+    "babel-preset-react": "^6.5.0",
+    "eslint": "^2.13.1",
+    "eslint-config-standard": "^5.3.1",
+    "eslint-plugin-promise": "^1.3.2",
+    "eslint-plugin-react": "^5.2.2",
+    "eslint-plugin-standard": "^1.3.2",
+    "mocha": "^2.5.3",
+    "webpack": "^1.13.1"
+  },
+  "dependencies": {
+    "react": "^15.1.0",
+    "react-dom": "^15.1.0"
+  }
 }

--- a/src/Components/Home/index.jsx
+++ b/src/Components/Home/index.jsx
@@ -1,0 +1,5 @@
+import React from 'react'
+import { render } from 'react-dom'
+
+const app = document.getElementById('app')
+render(<p>Hey from react!</p>, app)

--- a/src/index.js
+++ b/src/index.js
@@ -1,1 +1,0 @@
-'use strict'

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -2,7 +2,7 @@ var join = require('path').join
 
 module.exports = {
 	context: __dirname,
-	entry: './src/Components/Home/index.jsx',
+	entry: join(__dirname, 'src', 'Components', 'Home', 'index.jsx'),
 
 	output: {
 		path: join(__dirname, 'dist'),
@@ -14,7 +14,7 @@ module.exports = {
 			{
 				test: /\.jsx?$/,
 				exclude: /(node_modules|bower_components)/,
-				loader: 'babel', // 'babel-loader' is also a legal name to reference
+				loader: 'babel',
 				query: {
 					presets: ['es2015', 'react']
 				}


### PR DESCRIPTION
- Webpack file names weren't windows friendly before. Now using
  `path.join` to fix that, and removed some obnoxious comments.
- The entry component is now the Home component in the Components
  directory.
- The battle between tabs v spaces in the package.json file has been
  awarded to npm. This time, npm, this time...
