### PR TITLE
docs(readme): add gitter badge, remove "é" accents

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,13 @@
-# Code Caf&eacute;
+# Code Cafe
 *A service supporting ad hoc meetings of the minds over food and drink.*
 
 [![Travis branch](https://img.shields.io/travis/LunaMinds/code-cafe/master.svg)](https://travis-ci.org/LunaMinds/code-cafe)
-[![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg?style=flat-square)](http://makeapullrequest.com) 
+[![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg)](http://makeapullrequest.com)
+[![Chat on Gitter](https://img.shields.io/gitter/room/LunaMinds/code-cafe.js.svg)](https://gitter.im/LunaMinds/code-cafe)
 
 [![js-standard-style](https://cdn.rawgit.com/feross/standard/master/badge.svg)](http://standardjs.com)
 
 > **Under development**
 
-## About Code Caf&eacute;
+## About Code Cafe
 Programming at a local caf&eacute; or restaurant? Post the location you're at or find others and collab with local coders.


### PR DESCRIPTION
Added a gitter badge to our list of badges at the top. Also, one of the
badges was "flat-square", and we decided to follow the "square" style
for all our badges, so that's been modified.
Since the é (e acute) character might not be allowed on some services,
we decided to ensure the name always uses a normal "e" in "Code Cafe",
thus the update to our headers.
