### PR TITLE
docs(core): explain config option, document shims

### DIFF
--- a/src/Components/index.jsx
+++ b/src/Components/index.jsx
@@ -1,8 +1,11 @@
 import React from 'react'
 import { render } from 'react-dom'
-import injectTapEventPlugin from 'react-tap-event-plugin'
 import UIProvider from 'material-ui/styles/MuiThemeProvider'
 
+/**
+ * @see https://github.com/callemall/material-ui#react-tap-event-plugin
+ */
+import injectTapEventPlugin from 'react-tap-event-plugin'
 injectTapEventPlugin()
 
 import Home from './Home/index.jsx'

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -18,6 +18,8 @@ module.exports = {
 		hot: true,
 		contentBase: './dist',
 		port: port,
+
+		/** Allows connections by ip, not just `localhost`. */
 		host: '0.0.0.0',
 	},
 


### PR DESCRIPTION
The `host` option for dev-server was kind of weird and not
self-explanatory. A comment has been added for clarity.
Also, the material ui library needs the TapEvent plugin and it looked
really weird. A comment has been added to explain that as well.
