### PR TITLE
Fix Travis-CI config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,9 @@
 ---
 language: node_js
 node_js:
-  - v4
-  - v5
-  - v6.2
+  - 4
+  - 5
+  - 6
 
   # Installs the latest version
   - node


### PR DESCRIPTION
The NVM versions were prefixed by a letter "v", something nvm dislikes
strongly.

