### PR TITLE
fix(config) Run the correct server

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "dev": "node dev-server.js",
     "build": "webpack",
     "postinstall": "npm run build",
-    "start": "node server.js",
+    "start": "node prod-server.js",
     "nightwatch": "nightwatch"
   },
   "keywords": [],


### PR DESCRIPTION
In production, things happen. Sometimes things don't. This commit fixes
the latter.
Our "start" script was pointing to the wrong file (after refactoring,
pulling out prod-server.js). That's been fixed.

