### PR TITLE
style(formatting) Add code style settings

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,9 @@
+root = true
+
+# global file settings
+[*]
+end_of_line = lf
+insert_final_newline = true
+charset = utf-8
+indent_style = tab
+trim_trailing_whitespace = true


### PR DESCRIPTION
Shiny new editorconfig file sets the default style behavior for
editors. Fixes a problem Sean and I were having, atom was defaulting to
spaces and messing up our files.

