### PR TITLE
fix(package) Glob expansion

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "description": "Ad-hoc meetups for social programming",
   "main": "src/Server/index.js",
   "scripts": {
-    "test": "mocha src/**/*spec.js --opts ./mocha.opts --require ./tests/jsdom-setup.js",
+    "test": "mocha 'src/**/*spec.js' --opts ./mocha.opts --require ./tests/jsdom-setup.js",
     "tdd": "npm test -- --watch --reporter min",
     "lint": "eslint src/**/*.{js,jsx}",
     "dev": "node dev-server.js",


### PR DESCRIPTION
For unknown reasons, the mocha glob wasn't expanding properly and only
resolving the first file. It's been fixed to find all test files.

