### PR TITLE
chore(expect): Remove expect

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,7 +55,6 @@
     "eslint-plugin-promise": "^3.4.0",
     "eslint-plugin-react": "^6.1.2",
     "eslint-plugin-standard": "^2.0.0",
-    "expect": "^1.20.2",
     "jest": "^20.0.4",
     "jsdom": "^9.9.1",
     "mocha": "^3.0.2",
@@ -67,9 +66,9 @@
     "webpack": "^1.13.2",
     "webpack-dev-server": "^1.14.1"
   },
-	"jest": {
-		"setupFiles": [
-			"./tests/jsdom-setup.js"
-		]
-	}
+  "jest": {
+    "setupFiles": [
+      "./tests/jsdom-setup.js"
+    ]
+  }
 }

--- a/src/Components/__tests__/CreateEvent.spec.js
+++ b/src/Components/__tests__/CreateEvent.spec.js
@@ -1,6 +1,5 @@
 import RaisedButton from 'material-ui/RaisedButton'
 import { CreateEvent, select } from '../CreateEvent.jsx'
-import expect, { createSpy } from 'expect'
 import { shallow } from 'enzyme'
 import React from 'react'
 
@@ -10,8 +9,8 @@ describe('<CreateEvent>', () => {
 
 	beforeEach(() => {
 		props = {
-			setEventName: createSpy(),
-			createEvent: createSpy(),
+			setEventName: jest.fn(),
+			createEvent: jest.fn(),
 			id: 'create',
 		}
 	})
@@ -39,7 +38,6 @@ describe('<CreateEvent>', () => {
 
 		setup().find('input').filter({name: 'eventName'}).simulate('input', event)
 
-		expect(props.setEventName).toHaveBeenCalled()
 		expect(props.setEventName).toHaveBeenCalledWith(value)
 	})
 
@@ -53,8 +51,8 @@ describe('<CreateEvent>', () => {
 
 	describe('submit button', () => {
 		const createHtmlEvent = () => ({
-			preventDefault: createSpy(),
-			stopPropagation: createSpy(),
+			preventDefault: jest.fn(),
+			stopPropagation: jest.fn(),
 		})
 
 		it('calls create event action', () => {
@@ -63,7 +61,6 @@ describe('<CreateEvent>', () => {
 			props.end = 42
 			props.eventName = 'Festival of Sweet Potatoes and Bacon Awesomeness'
 			setup().find(RaisedButton).filter({type: 'submit'}).simulate('click', event)
-			expect(props.createEvent).toHaveBeenCalled()
 			expect(props.createEvent).toHaveBeenCalledWith({
 				start: props.start,
 				end: props.end,

--- a/src/Components/__tests__/DateTimePicker.spec.js
+++ b/src/Components/__tests__/DateTimePicker.spec.js
@@ -1,5 +1,4 @@
 import React from 'react'
-import expect, { createSpy } from 'expect'
 import { shallow } from 'enzyme'
 
 import { DateTimePicker } from '../DateTimePicker/index.jsx'
@@ -11,20 +10,20 @@ describe('<DateTimePicker>', function () {
 	beforeEach(() => {
 		props = {
 			id: 'date-time-picker',
-			onChange: createSpy(),
+			onChange: jest.fn(),
 		}
 
 		picker = setup()
 	})
 
 	it('should report time changes', () => {
-		expect(props.onChange).toNotHaveBeenCalled()
+		expect(props.onChange).not.toHaveBeenCalled()
 		picker.find('TimePicker').simulate('change')
 		expect(props.onChange).toHaveBeenCalled()
 	})
 
 	it('should report date changes', () => {
-		expect(props.onChange).toNotHaveBeenCalled()
+		expect(props.onChange).not.toHaveBeenCalled()
 		picker.find('DatePicker').simulate('change')
 		expect(props.onChange).toHaveBeenCalled()
 	})
@@ -33,7 +32,7 @@ describe('<DateTimePicker>', function () {
 		const date = new Date('2020 12 31')
 
 		picker.find('DatePicker').props().onChange(null, date)
-		const updatedDate = props.onChange.calls[0].arguments[0]
+		const [updatedDate] = props.onChange.mock.calls[0]
 
 		expect(updatedDate.getFullYear()).toBe(2020)
 		expect(updatedDate.getMonth()).toBe(11) // 'cause JS month off by one
@@ -44,7 +43,7 @@ describe('<DateTimePicker>', function () {
 		const time = new Date('1970 01 01 4:20')
 
 		picker.find('TimePicker').props().onChange(null, time)
-		const updatedTime = props.onChange.calls[0].arguments[0]
+		const [updatedTime] = props.onChange.mock.calls[0]
 
 		expect(updatedTime.getHours()).toBe(4)
 		expect(updatedTime.getMinutes()).toBe(20)
@@ -56,7 +55,7 @@ describe('<DateTimePicker>', function () {
 
 		picker.find('DatePicker').props().onChange(null, date)
 		picker.find('TimePicker').props().onChange(null, time)
-		const updatedDateTime = props.onChange.calls[1].arguments[0]
+		const [updatedDateTime] = props.onChange.mock.calls[1]
 
 		expect(updatedDateTime.getFullYear()).toBe(2020)
 		expect(updatedDateTime.getMonth()).toBe(11) // 'cause JS month off by one

--- a/src/Components/__tests__/DateTimeRange.spec.js
+++ b/src/Components/__tests__/DateTimeRange.spec.js
@@ -1,5 +1,4 @@
 import React from 'react'
-import expect, { createSpy } from 'expect'
 import { shallow } from 'enzyme'
 
 import { DateTimeRange } from '../DateTimeRange.jsx'
@@ -10,7 +9,7 @@ describe('<DateTimeRange>', () => {
 
 	beforeEach(() => {
 		props = {
-			setEventTimes: createSpy(),
+			setEventTimes: jest.fn(),
 			start: 123,
 			end: 456,
 		}
@@ -23,7 +22,7 @@ describe('<DateTimeRange>', () => {
 
 		expect(props.setEventTimes).toHaveBeenCalled()
 
-		const {start, end} = props.setEventTimes.calls[0].arguments[0]
+		const [{start, end}] = props.setEventTimes.mock.calls[0]
 		const hour = 1000 * 60 * 60
 
 		expect(end - start).toBe(hour)
@@ -33,7 +32,6 @@ describe('<DateTimeRange>', () => {
 		const date = new Date(123)
 		range.find('DateTimePicker').at(0).simulate('change', date)
 
-		expect(props.setEventTimes).toHaveBeenCalled()
 		expect(props.setEventTimes).toHaveBeenCalledWith({
 			start: date.getTime(),
 		})
@@ -54,23 +52,23 @@ describe('<DateTimeRange>', () => {
 
 		expect(props.setEventTimes).toHaveBeenCalled()
 
-		const {start, end} = props.setEventTimes.calls[0].arguments[0]
+		const [{start, end}] = props.setEventTimes.mock.calls[0]
 
-		expect(start).toBeA('number')
-		expect(end).toBeA('number')
+		expect(start).toEqual(expect.any(Number))
+		expect(end).toEqual(expect.any(Number))
 	})
 
 	it('uses the correct start date time', () => {
 		const dateTime = range.find('DateTimePicker').at(0).prop('value')
 
-		expect(dateTime).toBeA(Date)
+		expect(dateTime).toEqual(expect.any(Date))
 		expect(dateTime.getTime()).toBe(props.start)
 	})
 
 	it('uses the correct end date time', () => {
 		const dateTime = range.find('DateTimePicker').at(1).prop('value')
 
-		expect(dateTime).toBeA(Date)
+		expect(dateTime).toEqual(expect.any(Date))
 		expect(dateTime.getTime()).toBe(props.end)
 	})
 

--- a/src/Reducers/__tests__/spec.js
+++ b/src/Reducers/__tests__/spec.js
@@ -1,5 +1,3 @@
-import expect from 'expect'
-
 import * as Actions from '../../Actions'
 import reducer from '../index'
 
@@ -39,7 +37,7 @@ describe('reducer', () => {
 		const action = Actions.setEventTimes({end: 3})
 		const state = reducer(initial, action)
 
-		expect(state).toContain(initial)
+		expect(state).toEqual(expect.objectContaining(initial))
 	})
 
 	it('patches the event name', () => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -984,11 +984,7 @@ babylon@^6.11.0, babylon@^6.13.0:
   version "6.14.1"
   resolved "https://registry.yarnpkg.com/babylon/-/babylon-6.14.1.tgz#956275fab72753ad9b3435d7afe58f8bf0a29815"
 
-babylon@^6.15.0:
-  version "6.16.1"
-  resolved "https://registry.yarnpkg.com/babylon/-/babylon-6.16.1.tgz#30c5a22f481978a9e7f8cdfdf496b11d94b404d3"
-
-babylon@^6.17.4:
+babylon@^6.15.0, babylon@^6.17.4:
   version "6.17.4"
   resolved "https://registry.yarnpkg.com/babylon/-/babylon-6.17.4.tgz#3e8b7402b88d22c3423e137a1577883b15ff869a"
 
@@ -1665,7 +1661,7 @@ default-require-extensions@^1.0.0:
   dependencies:
     strip-bom "^2.0.0"
 
-define-properties@^1.1.2, define-properties@~1.1.2:
+define-properties@^1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/define-properties/-/define-properties-1.1.2.tgz#83a73f2fea569898fb737193c8f873caf6d45c94"
   dependencies:
@@ -2104,18 +2100,6 @@ expand-range@^1.8.1:
   resolved "https://registry.yarnpkg.com/expand-range/-/expand-range-1.8.2.tgz#a299effd335fe2721ebae8e257ec79644fc85337"
   dependencies:
     fill-range "^2.1.0"
-
-expect@^1.20.2:
-  version "1.20.2"
-  resolved "https://registry.yarnpkg.com/expect/-/expect-1.20.2.tgz#d458fe4c56004036bae3232416a3f6361f04f965"
-  dependencies:
-    define-properties "~1.1.2"
-    has "^1.0.1"
-    is-equal "^1.5.1"
-    is-regex "^1.0.3"
-    object-inspect "^1.1.0"
-    object-keys "^1.0.9"
-    tmatch "^2.0.1"
 
 express@^4.13.3, express@^4.14.0:
   version "4.14.0"
@@ -2768,21 +2752,11 @@ is-arrayish@^0.2.1:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/is-arrayish/-/is-arrayish-0.2.1.tgz#77c99840527aa8ecb1a8ba697b80645a7a926a9d"
 
-is-arrow-function@^2.0.3:
-  version "2.0.3"
-  resolved "https://registry.yarnpkg.com/is-arrow-function/-/is-arrow-function-2.0.3.tgz#29be2c2d8d9450852b8bbafb635ba7b8d8e87ec2"
-  dependencies:
-    is-callable "^1.0.4"
-
 is-binary-path@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/is-binary-path/-/is-binary-path-1.0.1.tgz#75f16642b480f187a711c814161fd3a4a7655898"
   dependencies:
     binary-extensions "^1.0.0"
-
-is-boolean-object@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/is-boolean-object/-/is-boolean-object-1.0.0.tgz#98f8b28030684219a95f375cfbd88ce3405dff93"
 
 is-buffer@^1.0.2:
   version "1.1.4"
@@ -2794,7 +2768,7 @@ is-builtin-module@^1.0.0:
   dependencies:
     builtin-modules "^1.0.0"
 
-is-callable@^1.0.4, is-callable@^1.1.1, is-callable@^1.1.2, is-callable@^1.1.3:
+is-callable@^1.1.1, is-callable@^1.1.2, is-callable@^1.1.3:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/is-callable/-/is-callable-1.1.3.tgz#86eb75392805ddc33af71c92a0eedf74ee7604b2"
 
@@ -2817,22 +2791,6 @@ is-equal-shallow@^0.1.3:
   resolved "https://registry.yarnpkg.com/is-equal-shallow/-/is-equal-shallow-0.1.3.tgz#2238098fc221de0bcfa5d9eac4c45d638aa1c534"
   dependencies:
     is-primitive "^2.0.0"
-
-is-equal@^1.5.1:
-  version "1.5.3"
-  resolved "https://registry.yarnpkg.com/is-equal/-/is-equal-1.5.3.tgz#05b7fa3a1122cbc71c1ef41ce0142d5532013b29"
-  dependencies:
-    has "^1.0.1"
-    is-arrow-function "^2.0.3"
-    is-boolean-object "^1.0.0"
-    is-callable "^1.1.3"
-    is-date-object "^1.0.1"
-    is-generator-function "^1.0.3"
-    is-number-object "^1.0.3"
-    is-regex "^1.0.3"
-    is-string "^1.0.4"
-    is-symbol "^1.0.1"
-    object.entries "^1.0.3"
 
 is-extendable@^0.1.1:
   version "0.1.1"
@@ -2866,10 +2824,6 @@ is-function@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/is-function/-/is-function-1.0.1.tgz#12cfb98b65b57dd3d193a3121f5f6e2f437602b5"
 
-is-generator-function@^1.0.3:
-  version "1.0.6"
-  resolved "https://registry.yarnpkg.com/is-generator-function/-/is-generator-function-1.0.6.tgz#9e71653cd15fff341c79c4151460a131d31e9fc4"
-
 is-glob@^2.0.0, is-glob@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/is-glob/-/is-glob-2.0.1.tgz#d096f926a3ded5600f3fdfd91198cb0888c2d863"
@@ -2890,10 +2844,6 @@ is-my-json-valid@^2.10.0, is-my-json-valid@^2.12.4:
     generate-object-property "^1.1.0"
     jsonpointer "^4.0.0"
     xtend "^4.0.0"
-
-is-number-object@^1.0.3:
-  version "1.0.3"
-  resolved "https://registry.yarnpkg.com/is-number-object/-/is-number-object-1.0.3.tgz#f265ab89a9f445034ef6aff15a8f00b00f551799"
 
 is-number@^2.0.2, is-number@^2.1.0:
   version "2.1.0"
@@ -2956,10 +2906,6 @@ is-resolvable@^1.0.0:
 is-stream@^1.0.1:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/is-stream/-/is-stream-1.1.0.tgz#12d4a3dd4e68e0b79ceb8dbc84173ae80d91ca44"
-
-is-string@^1.0.4:
-  version "1.0.4"
-  resolved "https://registry.yarnpkg.com/is-string/-/is-string-1.0.4.tgz#cc3a9b69857d621e963725a24caeec873b826e64"
 
 is-subset@^0.1.1:
   version "0.1.1"
@@ -4062,15 +4008,11 @@ object-assign@^4.1.1:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/object-assign/-/object-assign-4.1.1.tgz#2109adc7965887cfc05cbbd442cac8bfbb360863"
 
-object-inspect@^1.1.0:
-  version "1.2.1"
-  resolved "http://registry.npmjs.org/object-inspect/-/object-inspect-1.2.1.tgz#3b62226eb8f6d441751c7d8f22a20ff80ac9dc3f"
-
 object-is@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/object-is/-/object-is-1.0.1.tgz#0aa60ec9989a0b3ed795cf4d06f62cf1ad6539b6"
 
-object-keys@^1.0.10, object-keys@^1.0.8, object-keys@^1.0.9:
+object-keys@^1.0.10, object-keys@^1.0.8:
   version "1.0.11"
   resolved "https://registry.yarnpkg.com/object-keys/-/object-keys-1.0.11.tgz#c54601778ad560f1142ce0e01bcca8b56d13426d"
 
@@ -5047,15 +4989,15 @@ right-align@^0.1.1:
   dependencies:
     align-text "^0.1.1"
 
-rimraf@2, rimraf@^2.2.8, rimraf@~2.5.1, rimraf@~2.5.4:
-  version "2.5.4"
-  resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-2.5.4.tgz#96800093cbf1a0c86bd95b4625467535c29dfa04"
+rimraf@2, rimraf@^2.2.8, rimraf@^2.6.1:
+  version "2.6.1"
+  resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-2.6.1.tgz#c2338ec643df7a1b7fe5c54fa86f57428a55f33d"
   dependencies:
     glob "^7.0.5"
 
-rimraf@^2.6.1:
-  version "2.6.1"
-  resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-2.6.1.tgz#c2338ec643df7a1b7fe5c54fa86f57428a55f33d"
+rimraf@~2.5.1, rimraf@~2.5.4:
+  version "2.5.4"
+  resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-2.5.4.tgz#96800093cbf1a0c86bd95b4625467535c29dfa04"
   dependencies:
     glob "^7.0.5"
 
@@ -5528,10 +5470,6 @@ timers-browserify@^2.0.2:
   resolved "https://registry.yarnpkg.com/timers-browserify/-/timers-browserify-2.0.2.tgz#ab4883cf597dcd50af211349a00fbca56ac86b86"
   dependencies:
     setimmediate "^1.0.4"
-
-tmatch@^2.0.1:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/tmatch/-/tmatch-2.0.1.tgz#0c56246f33f30da1b8d3d72895abaf16660f38cf"
 
 tmpl@1.0.x:
   version "1.0.4"


### PR DESCRIPTION
Jest comes with an assertion framework and it's wicked cool. This commit
replaces `expect` with jest's version.

